### PR TITLE
trivial bugfix in interactive documentation

### DIFF
--- a/marytts-server/src/main/resources/marytts/server/http/documentation.html
+++ b/marytts-server/src/main/resources/marytts/server/http/documentation.html
@@ -40,7 +40,7 @@ to build MARY clients.</p>
 <code>locales</code> requests the list of available locales
 </p>
 
-<p><code><a href="voices">voices</a></code></p>
+<p><code><a href="locales">locales</a></code></p>
 
 
 <h3 id="voices">Available voices</h3>


### PR DESCRIPTION
the `voices` link was there twice, and the `locales` link was missing
