### PR TITLE
Require Java 1.6 when building voice..

### DIFF
--- a/marytts-builder/src/main/resources/marytts/tools/voiceimport/templates/pom.xml
+++ b/marytts-builder/src/main/resources/marytts/tools/voiceimport/templates/pom.xml
@@ -84,6 +84,19 @@
 					</execution>
 				</executions>
 			</plugin>
+			
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.3.2</version>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+					<encoding>${project.build.sourceEncoding}</encoding>
+				</configuration>
+			</plugin>
+			
+			
 			<plugin>
 				<groupId>org.codehaus.gmaven</groupId>
 				<artifactId>gmaven-plugin</artifactId>


### PR DESCRIPTION
This is the first pull request replacing the old big pull request.  This commit solves an issue similar to the one solved by Marcela in another pull request.
