### PR TITLE
Changed WikipediaMarkupCleaner.java to add a dot at the end of sections' titles.

### DIFF
--- a/marytts-builder/src/main/java/marytts/tools/dbselection/WikipediaMarkupCleaner.java
+++ b/marytts-builder/src/main/java/marytts/tools/dbselection/WikipediaMarkupCleaner.java
@@ -404,10 +404,14 @@ public class WikipediaMarkupCleaner {
                line = new StringBuffer(line.toString().replaceAll("…", " "));
                
                // finally sections and lists
-               line = new StringBuffer(line.toString().replaceAll("=====", ""));
-               line = new StringBuffer(line.toString().replaceAll("====", ""));
-               line = new StringBuffer(line.toString().replaceAll("===", ""));
-               line = new StringBuffer(line.toString().replaceAll("==", ""));
+			   boolean is_title = false;
+			   if (line.toString().startsWith("==")) {
+				   is_title = true;
+			   }
+               line = new StringBuffer(line.toString().replaceAll("\\s*==+$|==+", ""));
+               if(is_title){
+            	   line.append(".");
+               }
                
                // bulleted list and numbered list
                if( line.toString().startsWith("***") || line.toString().startsWith("*#*") )


### PR DESCRIPTION
Changed WikipediaMarkupCleaner.java to add a dot at the end of sections' titles, so that they are not attached to the begin of the subsequent sentence.
