### PR TITLE
Reduce long phoneme treshold on Quality Control

### DIFF
--- a/marytts-builder/src/main/java/marytts/tools/voiceimport/QualityControl.java
+++ b/marytts-builder/src/main/java/marytts/tools/voiceimport/QualityControl.java
@@ -256,7 +256,7 @@ public class QualityControl extends VoiceImportComponent {
         unit = labelUnit;
         double phoneDuration =  endTimeStamp - startTimeStamp;
         String currentProblem = "";
-        if( phoneDuration > 1 && !labelUnit.equals("_") && getProp(MLONGPHN).equals("true")){
+        if( phoneDuration > .4 && !labelUnit.equals("_") && getProp(MLONGPHN).equals("true")){
             currentProblem = labelUnit+"\t"+startTimeStamp+"\t"+endTimeStamp+"\tUnusually Long Phone";
             cost += 4;
         }


### PR DESCRIPTION
One second threshold seems too long for phonemes Quality Control. 0.4 seconds seems more reasonable (it will report some false positives, but most of the reports are good).
