### PR TITLE
Added several methods to JPhonemiser.java.

### DIFF
--- a/marytts-jungle/src/test/java/marytts/tests/modules/CompareLexiconLTS.java
+++ b/marytts-jungle/src/test/java/marytts/tests/modules/CompareLexiconLTS.java
@@ -24,6 +24,7 @@ import java.io.FileInputStream;
 import java.io.InputStreamReader;
 
 import marytts.modules.phonemiser.AllophoneSet;
+import marytts.modules.phonemiser.Syllabifier;
 import marytts.modules.phonemiser.TrainedLTS;
 
 public class CompareLexiconLTS {
@@ -45,7 +46,8 @@ public class CompareLexiconLTS {
         	myRemoveTrailingOneFromPhones = Boolean.getBoolean(args[3]);
         }
         
-        TrainedLTS lts = new TrainedLTS(AllophoneSet.getAllophoneSet(allophoneFile), new FileInputStream(ltsFile), myRemoveTrailingOneFromPhones);
+        TrainedLTS lts = new TrainedLTS(AllophoneSet.getAllophoneSet(allophoneFile), new FileInputStream(ltsFile), myRemoveTrailingOneFromPhones, new Syllabifier(AllophoneSet.getAllophoneSet(allophoneFile),
+        		myRemoveTrailingOneFromPhones));
 
         int count = 0;
         int correct = 0;

--- a/marytts-lang-de/src/main/java/marytts/language/de/JPhonemiser.java
+++ b/marytts-lang-de/src/main/java/marytts/language/de/JPhonemiser.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -72,7 +73,7 @@ public class JPhonemiser extends marytts.modules.JPhonemiser
     private PhonemiseDenglish phonemiseDenglish;
     
     public JPhonemiser()
-    throws IOException,  MaryConfigurationException
+    throws IOException,  MaryConfigurationException, SecurityException, IllegalArgumentException, NoSuchMethodException, ClassNotFoundException, InstantiationException, IllegalAccessException, InvocationTargetException
     {
       	super("JPhonemiser_de",
         MaryDataType.PARTSOFSPEECH,

--- a/marytts-runtime/src/main/java/marytts/modules/JPhonemiser.java
+++ b/marytts-runtime/src/main/java/marytts/modules/JPhonemiser.java
@@ -156,6 +156,7 @@ public class JPhonemiser extends InternalModule
             this.removeTrailingOneFromPhones = MaryProperties.getBoolean(removetrailingonefromphonesProperty, true);
 		}
 		Syllabifier syllabifier = null;
+		// how do you know about syllabifierClassProperty? (de = null, other true)
 		if (syllabifierClassProperty != null) {
 			String className = MaryProperties.getProperty(
 					syllabifierClassProperty, null);
@@ -165,7 +166,11 @@ public class JPhonemiser extends InternalModule
 				syllabifier = (Syllabifier) c.newInstance(this.allophoneSet,
 						this.removeTrailingOneFromPhones);
 			}
-		} else {
+			// className is null for all lang except italian...    
+		}
+        // if a syllabifier is not set go with the default  
+		if (syllabifier == null)
+		{
 			syllabifier = new Syllabifier(this.allophoneSet,
 					this.removeTrailingOneFromPhones);
 		}

--- a/marytts-runtime/src/main/java/marytts/modules/JPhonemiser.java
+++ b/marytts-runtime/src/main/java/marytts/modules/JPhonemiser.java
@@ -25,6 +25,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -37,6 +39,7 @@ import marytts.datatypes.MaryXML;
 import marytts.exceptions.MaryConfigurationException;
 import marytts.fst.FSTLookup;
 import marytts.modules.phonemiser.AllophoneSet;
+import marytts.modules.phonemiser.Syllabifier;
 import marytts.modules.phonemiser.TrainedLTS;
 import marytts.server.MaryProperties;
 import marytts.util.MaryRuntimeUtils;
@@ -66,14 +69,15 @@ public class JPhonemiser extends InternalModule
     protected AllophoneSet allophoneSet;
 
     public JPhonemiser(String propertyPrefix)
-    throws IOException,  MaryConfigurationException
+    throws IOException,  MaryConfigurationException, SecurityException, IllegalArgumentException, NoSuchMethodException, ClassNotFoundException, InstantiationException, IllegalAccessException, InvocationTargetException
     {
         this("JPhonemiser", MaryDataType.PARTSOFSPEECH, MaryDataType.PHONEMES,
         		propertyPrefix+"allophoneset",
                 propertyPrefix+"userdict",
                 propertyPrefix+"lexicon",
                 propertyPrefix+"lettertosound",
-                propertyPrefix+"removeTrailingOneFromPhones");
+                propertyPrefix+"removeTrailingOneFromPhones",
+                propertyPrefix+"syllabifierClass");
     }
     
     
@@ -83,15 +87,33 @@ public class JPhonemiser extends InternalModule
      * @param userdictFilename
      * @param lexiconFilename
      * @param ltsFilename
+     * @throws InvocationTargetException 
+     * @throws IllegalAccessException 
+     * @throws InstantiationException 
+     * @throws ClassNotFoundException 
+     * @throws NoSuchMethodException 
+     * @throws IllegalArgumentException 
+     * @throws SecurityException 
      * @throws Exception
      */
     public JPhonemiser(String componentName, 
             MaryDataType inputType, MaryDataType outputType,
             String allophonesProperty, String userdictProperty, String lexiconProperty, String ltsProperty)
-    throws IOException, MaryConfigurationException
+    throws IOException, MaryConfigurationException, SecurityException, IllegalArgumentException, NoSuchMethodException, ClassNotFoundException, InstantiationException, IllegalAccessException, InvocationTargetException
     {
         this(componentName, inputType, outputType,
-        		allophonesProperty, userdictProperty, lexiconProperty, ltsProperty, null);
+        		allophonesProperty, userdictProperty, lexiconProperty, ltsProperty, null, null);
+    }
+
+    /**
+	 * 
+	 * Set syllabifier component.
+	 * 
+	 * @param syllabifier
+	 * 
+	 */
+    public void setSyllabifier(Syllabifier syllabifier){
+    	this.lts.setSyllabifier(syllabifier);
     }
 
     /**
@@ -101,12 +123,19 @@ public class JPhonemiser extends InternalModule
      * @param lexiconFilename
      * @param ltsFilename
      * @param removetrailingonefromphonesBoolean
+     * @throws ClassNotFoundException 
+     * @throws NoSuchMethodException 
+     * @throws SecurityException 
+     * @throws InvocationTargetException 
+     * @throws IllegalAccessException 
+     * @throws InstantiationException 
+     * @throws IllegalArgumentException 
      * @throws Exception
      */
     public JPhonemiser(String componentName, 
             MaryDataType inputType, MaryDataType outputType,
-            String allophonesProperty, String userdictProperty, String lexiconProperty, String ltsProperty, String removetrailingonefromphonesProperty)
-    throws IOException, MaryConfigurationException
+            String allophonesProperty, String userdictProperty, String lexiconProperty, String ltsProperty, String removetrailingonefromphonesProperty, String syllabifierClassProperty)
+    throws IOException, MaryConfigurationException, SecurityException, NoSuchMethodException, ClassNotFoundException, IllegalArgumentException, InstantiationException, IllegalAccessException, InvocationTargetException
     {
         super(componentName, inputType, outputType,
         		MaryRuntimeUtils.needAllophoneSet(allophonesProperty).getLocale());
@@ -125,8 +154,22 @@ public class JPhonemiser extends InternalModule
         InputStream ltsStream = MaryProperties.needStream(ltsProperty);
         if(removetrailingonefromphonesProperty != null){
             this.removeTrailingOneFromPhones = MaryProperties.getBoolean(removetrailingonefromphonesProperty, true);
-        }
-        lts = new TrainedLTS(allophoneSet, ltsStream, this.removeTrailingOneFromPhones);
+		}
+		Syllabifier syllabifier = null;
+		if (syllabifierClassProperty != null) {
+			String className = MaryProperties.getProperty(
+					syllabifierClassProperty, null);
+			if (className != null) {
+				Constructor c = Class.forName(className).getConstructor(
+						AllophoneSet.class, boolean.class);
+				syllabifier = (Syllabifier) c.newInstance(this.allophoneSet,
+						this.removeTrailingOneFromPhones);
+			}
+		} else {
+			syllabifier = new Syllabifier(this.allophoneSet,
+					this.removeTrailingOneFromPhones);
+		}
+        lts = new TrainedLTS(allophoneSet, ltsStream, this.removeTrailingOneFromPhones, syllabifier);
     }
 
 

--- a/marytts-runtime/src/main/java/marytts/modules/phonemiser/TrainedLTS.java
+++ b/marytts-runtime/src/main/java/marytts/modules/phonemiser/TrainedLTS.java
@@ -52,24 +52,29 @@ public class TrainedLTS {
     private AllophoneSet allophoneSet;
     private boolean convertToLowercase;
     protected boolean removeTrailingOneFromPhones = true;
+    protected Syllabifier syllabifier = null;
     
     /**
-     * 
-     * Initializes letter to sound system with a phoneSet, and load the decision
-     * tree from the given file.
-     * 
-     * @param aPhonSet phoneset used in syllabification
-     * @param treeFilename
-     * @param removeTrailingOneFromPhones
-     * @throws IOException 
-     * 
-     */
-    public TrainedLTS(AllophoneSet aPhonSet, InputStream treeStream, boolean removeTrailingOneFromPhones)
-    throws IOException, MaryConfigurationException {
-        this.allophoneSet = aPhonSet;
-        this.loadTree(treeStream);
-        this.removeTrailingOneFromPhones = removeTrailingOneFromPhones;
-    }
+	 * 
+	 * Initializes letter to sound system with a phoneSet, and load the decision
+	 * tree from the given file.
+	 * 
+	 * @param aPhonSet
+	 *            phoneset used in syllabification
+	 * @param treeFilename
+	 * @param removeTrailingOneFromPhones
+	 * @param syllabifier
+	 * @throws IOException
+	 * 
+	 */
+	public TrainedLTS(AllophoneSet aPhonSet, InputStream treeStream,
+			boolean removeTrailingOneFromPhones, Syllabifier syllabifier)
+			throws IOException, MaryConfigurationException {
+		this.allophoneSet = aPhonSet;
+		this.loadTree(treeStream);
+		this.removeTrailingOneFromPhones = removeTrailingOneFromPhones;
+		this.syllabifier = syllabifier;
+	}
     
     /**
      * 
@@ -83,7 +88,9 @@ public class TrainedLTS {
      */
     public TrainedLTS(AllophoneSet aPhonSet, InputStream treeStream)
     throws IOException, MaryConfigurationException {
-        this(aPhonSet, treeStream, true);
+        this(aPhonSet, treeStream, true, null);
+		this.syllabifier = new Syllabifier(this.allophoneSet,
+				this.removeTrailingOneFromPhones);
     }
     
     public TrainedLTS(AllophoneSet aPhonSet, CART predictionTree) {
@@ -164,10 +171,21 @@ public class TrainedLTS {
      * @return phone chain, with syllable sepeators "-" and stress symbols "'"
      */
     public String syllabify(String phones){
+        if(syllabifier != null)
+        	return syllabifier.syllabify(phones);
         
-        Syllabifier sfr = new Syllabifier(this.allophoneSet, this.removeTrailingOneFromPhones);
-        
-        return sfr.syllabify(phones);
+        return null;
+    }
+
+    /**
+	 * 
+	 * Set syllabifier component.
+	 * 
+	 * @param syllabifier
+	 * 
+	 */
+    public void setSyllabifier(Syllabifier syllabifier){
+    	this.syllabifier = syllabifier;
     }
     
     public static void main(String[] args) throws IOException, MaryConfigurationException {
@@ -184,7 +202,8 @@ public class TrainedLTS {
         	myRemoveTrailingOneFromPhones = Boolean.getBoolean(args[2]);
         }
         
-        TrainedLTS lts = new TrainedLTS(AllophoneSet.getAllophoneSet(allophoneFile), new FileInputStream(ltsFile), myRemoveTrailingOneFromPhones);
+        TrainedLTS lts = new TrainedLTS(AllophoneSet.getAllophoneSet(allophoneFile), new FileInputStream(ltsFile), myRemoveTrailingOneFromPhones, new Syllabifier(AllophoneSet.getAllophoneSet(allophoneFile),
+        		myRemoveTrailingOneFromPhones));
 
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         String line;

--- a/marytts-transcription/src/main/java/marytts/tools/transcription/LTSLexiconPOSBuilder.java
+++ b/marytts-transcription/src/main/java/marytts/tools/transcription/LTSLexiconPOSBuilder.java
@@ -31,6 +31,7 @@ import marytts.features.FeatureDefinition;
 import marytts.fst.AlignerTrainer;
 import marytts.fst.StringPair;
 import marytts.modules.phonemiser.AllophoneSet;
+import marytts.modules.phonemiser.Syllabifier;
 import marytts.modules.phonemiser.TrainedLTS;
 import marytts.tools.dbselection.DBHandler;
 import marytts.tools.newlanguage.LTSTrainer;
@@ -117,13 +118,15 @@ public class LTSLexiconPOSBuilder {
      * train and predict module
      * 
      * @param treeAbsolutePath
+     * @param myRemoveTrailingOneFromPhones
      * @throws IOException
      * @throws MaryConfigurationException 
      */
-    public void trainPredict(String treeAbsolutePath) throws IOException, MaryConfigurationException {
+    public void trainPredict(String treeAbsolutePath, boolean myRemoveTrailingOneFromPhones) throws IOException, MaryConfigurationException {
         Object[][] tableData = transcriptionModel.getData();
         boolean[] hasManualVerify = transcriptionModel.getManualVerifiedList();
         boolean[] hasCorrectSyntax = transcriptionModel.getCorrectSyntaxList();
+        this.removeTrailingOneFromPhones = myRemoveTrailingOneFromPhones;
 
         // Check for number of manual entries available
         int numberOfManualEntries = 0;
@@ -138,7 +141,8 @@ public class LTSLexiconPOSBuilder {
 
         trainLTS(treeAbsolutePath);
         FileInputStream fis = new FileInputStream(treeAbsolutePath);
-        TrainedLTS trainedLTS = new TrainedLTS(phoneSet, fis, this.removeTrailingOneFromPhones);
+        TrainedLTS trainedLTS = new TrainedLTS(phoneSet, fis, this.removeTrailingOneFromPhones, new Syllabifier(phoneSet,
+        		this.removeTrailingOneFromPhones));
         for (int i = 0; i < tableData.length; i++) {
             if (!(hasManualVerify[i] && hasCorrectSyntax[i])) {
                 String grapheme = (String) tableData[i][1];
@@ -257,7 +261,7 @@ public class LTSLexiconPOSBuilder {
 
             // Procedure
             System.out.println("trainPredict ...");
-            myLTSLexiconPOSBuilder.trainPredict(treeAbsolutePath);
+            myLTSLexiconPOSBuilder.trainPredict(treeAbsolutePath, myRemoveTrailingOneFromPhones);
             System.out.println("... done.");
 
             System.out.println("saveTranscription ...");

--- a/marytts-transcription/src/main/java/marytts/tools/transcription/TranscriptionTable.java
+++ b/marytts-transcription/src/main/java/marytts/tools/transcription/TranscriptionTable.java
@@ -49,6 +49,7 @@ import javax.swing.table.TableColumn;
 import marytts.cart.CART;
 import marytts.exceptions.MaryConfigurationException;
 import marytts.modules.phonemiser.AllophoneSet;
+import marytts.modules.phonemiser.Syllabifier;
 import marytts.modules.phonemiser.TrainedLTS;
 import marytts.tools.newlanguage.LTSTrainer;
 
@@ -202,7 +203,7 @@ public class TranscriptionTable extends JPanel implements ActionListener {
         try {
             LTSTrainer tp = this.trainLTS(treeAbsolutePath);
             FileInputStream fis = new FileInputStream(treeAbsolutePath);
-            TrainedLTS trainedLTS = new TrainedLTS(phoneSet, fis, this.removeTrailingOneFromPhones);
+            TrainedLTS trainedLTS = new TrainedLTS(phoneSet, fis, this.removeTrailingOneFromPhones, new Syllabifier(phoneSet,this.removeTrailingOneFromPhones));
         	fis.close();
             for(int i=0;i<tableData.length; i++){
                 if(!(hasManualVerify[i] && hasCorrectSyntax[i])){


### PR DESCRIPTION
This pull request adds the following methods:
- dictLookup(): lookup in just one dictionary;
- phonemiseLookupOnly(): lookup in a sequence of dictionaries and with
                       some text normalisation as well.
- phonemiseComplete(): lookup in a sequence of dictionaries, with text
             normalisation and letter to sound.

The original purpose of these methods was to allow the support for per-request dictionaries, but I think they are useful in the general case: dictLookup() can be used to perform lookup in any given dictionary (passed as an argument); phonemiseLookupOnly() allows to perform only the lookup part, of the phonemise method, without LTS; phonemiseComplete() allows the usage of a dictionary passed at runtime, so that per-request dictionaries can be used.

The pull request also allows to use custom Syllabifier with JPhonemiser instances, simplifying the use of custom Syllabifier for specific languages.
