### PR TITLE
Pitch statistics

### DIFF
--- a/marytts-assembly/assembly-builder/src/builder/bin/pitch_statistics.m
+++ b/marytts-assembly/assembly-builder/src/builder/bin/pitch_statistics.m
@@ -1,0 +1,26 @@
+#! /bin/octave -qf
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% pitch_statistics.sh
+% Author: Fabio Tesser
+% Email: fabio.tesser@gmail.com
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+printf ("%s\n", program_name ());
+arg_list = argv ();
+
+filename=arg_list{1};
+epsfilename=sprintf("%s_pitch_statistics.eps",filename);
+
+f0 = load(filename);
+hist(f0,200);
+print("-depsc",epsfilename);
+
+printf("The statistics of f0\nmean: %f, std %f, min %f, max %f\n",mean(f0),std(f0),min(f0),max(f0));
+
+delta=0.5;
+P=[percentile(f0,delta) percentile(f0,100-delta)];
+printf("The percentiles at %f %s and %f %s are: [%f - %f]\n", delta,"%", 100-delta, "%",P(1),P(2));
+
+exit;
+

--- a/marytts-assembly/assembly-builder/src/builder/bin/pitch_statistics.m
+++ b/marytts-assembly/assembly-builder/src/builder/bin/pitch_statistics.m
@@ -12,15 +12,49 @@ arg_list = argv ();
 filename=arg_list{1};
 epsfilename=sprintf("%s_pitch_statistics.eps",filename);
 
-f0 = load(filename);
-hist(f0,200);
-print("-depsc",epsfilename);
+[DIR, NAME, EXT, VER] = fileparts (filename);
+[STATUS, RESULT, MSGID] = fileattrib (DIR);
+[DIR, NAME, EXT, VER] = fileparts (RESULT.Name);
+[DIR, NAME, EXT, VER] = fileparts (DIR);
 
+NAME
+
+f0 = load(filename);
 printf("The statistics of f0\nmean: %f, std %f, min %f, max %f\n",mean(f0),std(f0),min(f0),max(f0));
 
-delta=0.5;
-P=[percentile(f0,delta) percentile(f0,100-delta)];
-printf("The percentiles at %f %s and %f %s are: [%f - %f]\n", delta,"%", 100-delta, "%",P(1),P(2));
+delta1=0.1;
+P1=[percentile(f0,delta1) percentile(f0,100-delta1)];
+printf("The percentiles at %f %s and %f %s are: [%f - %f]\n", delta1,"%", 100-delta1, "%",P1(1),P1(2));
+
+delta2=0.5;
+P2=[percentile(f0,delta2) percentile(f0,100-delta2)];
+printf("The percentiles at %f %s and %f %s are: [%f - %f]\n", delta2,"%", 100-delta2, "%",P2(1),P2(2));
+
+figure;
+[NN, XX]=hist(f0,200);
+bar(XX,NN);
+
+%mean(XX)
+%mean(NN)
+
+%figure;
+%hist(f0,200);
+grid on;
+title (sprintf("%s f0 - mean: %f, std %f, min %f, max %f\n%0.1f-%0.1f percentiles: [%f - %f]\n%0.1f-%0.1f percentiles: [%f - %f]\n",NAME,mean(f0),std(f0),min(f0),max(f0),delta1,100-delta1,P1(1),P1(2),delta2,100-delta2,P2(1),P2(2)
+));
+
+xlabel ("Hz");
+ylabel ("Frames");
+
+
+line([P1(1);P1(1)],[0; max(NN)],"linestyle","-.", "color", "blue");
+line([P1(2);P1(2)],[0; max(NN)],"linestyle","-.", "color", "blue");
+
+line([P2(1);P2(1)],[0; max(NN)],"linestyle","-.", "color", "magenta");
+line([P2(2);P2(2)],[0; max(NN)],"linestyle","-.", "color", "magenta");
+
+
+print("-depsc",epsfilename);
 
 exit;
 

--- a/marytts-assembly/assembly-builder/src/builder/bin/pitch_statistics.sh
+++ b/marytts-assembly/assembly-builder/src/builder/bin/pitch_statistics.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+##################################
+# pitch_statistics.sh
+# Author: Fabio Tesser
+# Email: fabio.tesser@gmail.com
+##################################
+
+# EXIT ERROR settings 
+set -o errexit
+BINDIR="`dirname "$0"`"
+DESCRIPTION="Compute some statistics on pitch"
+
+NUMARG=1
+if [ $# -ne $NUMARG ]
+then
+  echo "NAME:
+  	`basename $0`
+
+DESCRIPTION:
+    $DESCRIPTION
+
+USAGE: 
+`basename $0` [PRAATPMDIR] 
+	PRAATPMDIR: pmDir
+
+EXAMPLE:
+	`basename $0` voice_buiding/pm" 
+  exit 1
+fi  
+
+PRAATPMDIR=$1
+
+cat $PRAATPMDIR/*.f0 | sort -n | sed -r -n -e '/[^0]/,$p' > $PRAATPMDIR/total.f0
+
+octave $BINDIR/pitch_statistics.m $PRAATPMDIR/total.f0 2>&1 | tee $PRAATPMDIR/total.f0.pitch_statistics.txt  
+
+

--- a/marytts-builder/src/main/resources/marytts/tools/voiceimport/script.praat
+++ b/marytts-builder/src/main/resources/marytts/tools/voiceimport/script.praat
@@ -47,6 +47,7 @@ for b to numBasenames
   wavFile$ = "'wavDir$'/'basename$'.wav"
   pitchFile$ = "'pmDir$'/'basename$'.Pitch"
   pointpFile$ = "'pmDir$'/'basename$'.PointProcess"
+  f0file$ = "'pmDir$'/'basename$'.f0"
 
   # provide current progress as text file "percent":
   percent = floor(b / numBasenames * 100)
@@ -77,13 +78,25 @@ if fileReadable(pitchFile$)
   pitch = Read from file... 'pitchFile$'
 else
   # determine pitch curve:
-  noprogress To Pitch... 0 minPitch maxPitch
+  #noprogress To Pitch... 0 minPitch maxPitch
+  noprogress To Pitch (ac)... 0 minPitch 15 yes 0.03 0.45 0.01 0.35 0.14 maxPitch
   pitch = selected()
+  Write to short text file... 'pitchFile$'
 endif
 
+# Transpose matrix
+select pitch
+To Matrix
+Transpose
+matrix_transpose = selected()
+Save as headerless spreadsheet file... 'f0file$'
+
 # Get some debug info: 
-min_f0 = Get minimum... 0 0 Hertz Parabolic
-max_f0 = Get maximum... 0 0 Hertz Parabolic
+select pitch
+min_f0 = Get minimum... 0 0 Hertz None
+max_f0 = Get maximum... 0 0 Hertz None
+mean_f0 = Get mean... 0 0 Hertz
+std_f0 = Get standard deviation... 0 0 Hertz
 
 # And convert to pitch marks:
 plus sound
@@ -168,7 +181,7 @@ endfor
 
 label writepp
 Write to short text file... 'pointpFile$'
-printline 'basename$'   f0 range: 'min_f0:0' - 'max_f0:0' Hz ('percent$'%)
+printline 'basename$'   f0 range: 'min_f0:0' - 'max_f0:0' Hz; f0 mean: 'mean_f0:0' - std: 'std_f0:0' ('percent$'%)
 
 # cleanup:
 plus wav


### PR DESCRIPTION
This pull request adds a tool able to compute some statistics about the pitch extracted form the corpus.

The praat script has been modified in order to save some auxiliary files (the raw f0 data), and to extract the pitch with the very accurate flag set on: 
noprogress To Pitch (ac)... 0 minPitch 15 yes 0.03 0.45 0.01 0.35 0.14 maxPitch

The script pitch_statistics requires Octave.
