### PR TITLE
Enhanced OutputStreams for Mary Client

### DIFF
--- a/marytts-client/src/main/java/marytts/client/AudioFormatOutputStream.java
+++ b/marytts-client/src/main/java/marytts/client/AudioFormatOutputStream.java
@@ -16,6 +16,10 @@ import javax.sound.sampled.AudioFormat;
  * the audio data as well as the {@link AudioFormat}of that data.
  * </p>
  * <p>
+ * It is also possible to extend this class and create a new internally used
+ * {@link OutputStream} once {@link #setFormat(AudioFormat)} has been called.
+ * </p>
+ * <p>
  * An example usage might be
  * <pre>
  * MaryClient processor = MaryClient.getMaryClient();
@@ -23,7 +27,7 @@ import javax.sound.sampled.AudioFormat;
  * AudioFormatOutputStream afos = new AudioFormatOutputStream(out);
  * processor.process("this is a test", "TEXT", "AUDIO", "en-US",
  *     "WAVE", "cmu-slt-hsmm", afos, 5000);
- * AudioFormat fromat = afos.getFormat());
+ * AudioFormat format = afos.getFormat());
  * </pre>
  * </p>
  * @author Dirk Schnelle-Walka
@@ -32,6 +36,9 @@ import javax.sound.sampled.AudioFormat;
 public class AudioFormatOutputStream extends OutputStream {
 	private OutputStream out;
 	private AudioFormat format;
+
+	protected AudioFormatOutputStream() {
+	}
 	
 	public AudioFormatOutputStream(OutputStream out) {
 		this.out = out;
@@ -55,11 +62,15 @@ public class AudioFormatOutputStream extends OutputStream {
 		return format;
 	}
 
-	public void setFormat(AudioFormat format) {
+	public void setFormat(AudioFormat format) throws IOException {
 		this.format = format;
 	}
 
-	public OutputStream getOut() {
+	protected void setOutputStream(OutputStream out) {
+		this.out = out;
+	}
+
+	public OutputStream getOutputStream() {
 		return out;
 	}
 }

--- a/marytts-client/src/main/java/marytts/client/AudioFormatOutputStream.java
+++ b/marytts-client/src/main/java/marytts/client/AudioFormatOutputStream.java
@@ -1,0 +1,65 @@
+package marytts.client;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import javax.sound.sampled.AudioFormat;
+
+/**
+ * Using an {@link OutputStream} in {@link MaryClient#process(String, String, String, String, String, String, OutputStream)} or
+ * {@link MaryClient#process(String, String, String, String, String, String, OutputStream, long)}
+ * does not provide any hints on the audio format that is being sent by mary.
+ * This poses difficulties in playing back the audio since the actual format
+ * depends on the voice used.
+ * <p>
+ * This class encapsulates an {@link OutputStream} that would be used to carry
+ * the audio data as well as the {@link AudioFormat}of that data.
+ * </p>
+ * <p>
+ * An example usage might be
+ * <pre>
+ * MaryClient processor = MaryClient.getMaryClient();
+ * ByteArrayOutputStream out = new ByteArrayOutputStream();
+ * AudioFormatOutputStream afos = new AudioFormatOutputStream(out);
+ * processor.process("this is a test", "TEXT", "AUDIO", "en-US",
+ *     "WAVE", "cmu-slt-hsmm", afos, 5000);
+ * AudioFormat fromat = afos.getFormat());
+ * </pre>
+ * </p>
+ * @author Dirk Schnelle-Walka
+ *
+ */
+public class AudioFormatOutputStream extends OutputStream {
+	private OutputStream out;
+	private AudioFormat format;
+	
+	public AudioFormatOutputStream(OutputStream out) {
+		this.out = out;
+	}
+	
+	@Override
+	public void write(int b) throws IOException {
+		out.write(b);
+	}
+
+	@Override
+	public void write(byte[] b) throws IOException {
+		out.write(b);
+	}
+	
+	public void write(byte[] b, int off, int len) throws IOException {
+		out.write(b, off, len);
+	}
+
+	public AudioFormat getFormat() {
+		return format;
+	}
+
+	public void setFormat(AudioFormat format) {
+		this.format = format;
+	}
+
+	public OutputStream getOut() {
+		return out;
+	}
+}

--- a/marytts-client/src/main/java/marytts/client/http/MaryHttpClient.java
+++ b/marytts-client/src/main/java/marytts/client/http/MaryHttpClient.java
@@ -42,7 +42,9 @@ import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.AudioFormat.Encoding;
+import javax.sound.sampled.UnsupportedAudioFileException;
 
+import marytts.client.AudioFormatOutputStream;
 import marytts.client.MaryClient;
 import marytts.client.MaryGUIClient;
 import marytts.util.http.Address;
@@ -581,6 +583,15 @@ public class MaryHttpClient extends MaryClient
         { 
             OutputStream os = (OutputStream) output;
             InputStream bis = new BufferedInputStream(fromServerStream);
+            if (os instanceof AudioFormatOutputStream) {
+                AudioFormatOutputStream afos = (AudioFormatOutputStream) os;
+                try {
+					AudioFileFormat format = AudioSystem.getAudioFileFormat(bis);
+					afos.setFormat(format.getFormat());
+				} catch (UnsupportedAudioFileException e) {
+					throw new IOException(e.getMessage(), e);
+				}
+            }
             byte[] bbuf = new byte[1024];
             int nr;
             while ((nr = bis.read(bbuf, 0, bbuf.length)) != -1) 


### PR DESCRIPTION
Added the possibility to retrieve the used audio format if an OutputStream is used instead of the AudioPlayer.

This version is actively used in JVoiceXML.