### PR TITLE
fix(GUI): close FileOutputStream after audio save

### DIFF
--- a/marytts-client/src/main/java/marytts/client/MaryGUIClient.java
+++ b/marytts-client/src/main/java/marytts/client/MaryGUIClient.java
@@ -984,10 +984,12 @@ public class MaryGUIClient extends JPanel {
 					if (audioType == null) { // file has unknown extension
 						showErrorMessage("Unknown audio type", "Cannot write file of type `." + ext + "'");
 					} else { // OK, we know what to do
+						FileOutputStream fos = new FileOutputStream(saveFile);
 						processor.process(inputText.getText(), ((MaryClient.DataType) cbInputType.getSelectedItem()).name(),
 								"AUDIO", ((MaryClient.Voice) cbDefaultVoice.getSelectedItem()).getLocale().toString(), audioType,
 								((MaryClient.Voice) cbDefaultVoice.getSelectedItem()).name(), "", getAudioEffectsString(), null,
-								new FileOutputStream(saveFile));
+								fos);
+						fos.close();
 					}
 				}
 			}


### PR DESCRIPTION
Output file was locked on Windows 7 until program exit or different file saved.

Closes #198