### PR TITLE
Use https URLs whenever possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<licenses>
 		<license>
 			<name>GNU Lesser General Public License v3.0</name>
-			<url>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</url>
+			<url>https://www.gnu.org/licenses/lgpl-3.0-standalone.html</url>
 		</license>
 	</licenses>
 
@@ -117,7 +117,7 @@
 		</repository>
 		<snapshotRepository>
 			<id>bintray</id>
-			<url>http://oss.jfrog.org/artifactory/oss-snapshot-local</url>
+			<url>https://oss.jfrog.org/artifactory/oss-snapshot-local</url>
 		</snapshotRepository>
 	</distributionManagement>
 
@@ -378,7 +378,7 @@
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
-			<url>http://jcenter.bintray.com</url>
+			<url>https://jcenter.bintray.com</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
For security purposes, HTTPS (as opposed to HTTP) URLs should be used whenever possible.