### PR TITLE
Nz lex

### DIFF
--- a/marytts-languages/marytts-lang-en/src/main/java/marytts/language/en/Preprocess.java
+++ b/marytts-languages/marytts-lang-en/src/main/java/marytts/language/en/Preprocess.java
@@ -18,6 +18,7 @@ import marytts.datatypes.MaryXML;
 import marytts.exceptions.MaryConfigurationException;
 import marytts.modules.InternalModule;
 import marytts.util.MaryRuntimeUtils;
+import marytts.util.MaryUtils;
 import marytts.util.dom.MaryDomUtils;
 import marytts.util.dom.NameNodeFilter;
 
@@ -175,7 +176,8 @@ public class Preprocess extends InternalModule {
 
 	public MaryData process(MaryData d) throws Exception {
 		Document doc = d.getDocument();
-		expand(doc);
+		
+		expand(doc, d.getLocale());
 		MaryData result = new MaryData(getOutputType(), d.getLocale());
 		result.setDocument(doc);
 		return result;
@@ -188,7 +190,7 @@ public class Preprocess extends InternalModule {
 	 * @throws IOException
 	 * @throws MaryConfigurationException
 	 */
-	protected void expand(Document doc) throws ParseException, IOException, MaryConfigurationException {
+	protected void expand(Document doc, Locale locale) throws ParseException, IOException, MaryConfigurationException {
 		String whichCurrency = "";
 		boolean URLFirst = false;
 		boolean isYear;
@@ -284,7 +286,8 @@ public class Preprocess extends InternalModule {
 			// contractions
 			} else if (MaryDomUtils.tokenText(t).matches(contractPattern.pattern())) {
 				// first check lexicon
-				if (MaryRuntimeUtils.checkLexicon("en_US", MaryDomUtils.tokenText(t)).length == 0) {
+				
+				if (MaryRuntimeUtils.checkLexicon(locale.toString(), MaryDomUtils.tokenText(t)).length == 0) {
 					Matcher contractionMatch = contractPattern.matcher(MaryDomUtils.tokenText(t));
 					contractionMatch.find();
 					// if no contraction we allow g2p rules to handle

--- a/marytts-languages/marytts-lang-en/src/main/java/marytts/language/en/Preprocess.java
+++ b/marytts-languages/marytts-lang-en/src/main/java/marytts/language/en/Preprocess.java
@@ -18,7 +18,6 @@ import marytts.datatypes.MaryXML;
 import marytts.exceptions.MaryConfigurationException;
 import marytts.modules.InternalModule;
 import marytts.util.MaryRuntimeUtils;
-import marytts.util.MaryUtils;
 import marytts.util.dom.MaryDomUtils;
 import marytts.util.dom.NameNodeFilter;
 
@@ -286,8 +285,16 @@ public class Preprocess extends InternalModule {
 			// contractions
 			} else if (MaryDomUtils.tokenText(t).matches(contractPattern.pattern())) {
 				// first check lexicon
+				String localeText;
+				if (locale == null)
+				{
+					localeText = "en_US";
+				}
+				else {
+					localeText = locale.toString();
+				}
 				
-				if (MaryRuntimeUtils.checkLexicon(locale.toString(), MaryDomUtils.tokenText(t)).length == 0) {
+				if (MaryRuntimeUtils.checkLexicon(localeText, MaryDomUtils.tokenText(t)).length == 0) {
 					Matcher contractionMatch = contractPattern.matcher(MaryDomUtils.tokenText(t));
 					contractionMatch.find();
 					// if no contraction we allow g2p rules to handle

--- a/marytts-languages/marytts-lang-en/src/test/java/marytts/language/en/PreprocessTest.java
+++ b/marytts-languages/marytts-lang-en/src/test/java/marytts/language/en/PreprocessTest.java
@@ -121,7 +121,7 @@ public class PreprocessTest {
 		Document doc = mary.generateXML(lemma);
 		String words = "<maryxml xmlns=\"http://mary.dfki.de/2002/MaryXML\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" version=\"0.5\"><p><s><t>" + lemma + "</t></s></p></maryxml>";
 		Document expectedDoc = DomUtils.parseDocument(words);
-		module.expand(expectedDoc);
+		module.expand(expectedDoc, null);
 		Diff diff = XMLUnit.compareXML(expectedDoc, doc);
 		// issue where LocalMaryInterface#generateXML and DomUtils#parseDocument dont build the document in same order
 		Assert.assertFalse(diff.identical());


### PR DESCRIPTION
Modifications to en Preprocess module to allow checking for contractions for locale-specific dictionary (previously, contractions were only being searched in en_US, regardless of which English locale was being used).