### PR TITLE
o Fix missing header (unistd.h needed for close())

### DIFF
--- a/doc/examples/client/c++/Makefile
+++ b/doc/examples/client/c++/Makefile
@@ -8,7 +8,7 @@
 # distribute, sublicense, and/or sell copies of this work, and to
 # permit persons to whom this work is furnished to do so, subject to
 # the following conditions:
-# 
+#
 #  1. The code must retain the above copyright notice, this list of
 #     conditions and the following disclaimer.
 #  2. Any modifications must be clearly marked as such.
@@ -16,14 +16,14 @@
 #  4. The authors' names are not used to endorse or promote products
 #     derived from this software without specific prior written
 #     permission.
-# 
-# DFKI GMBH AND THE CONTRIBUTORS TO THIS WORK DISCLAIM ALL WARRANTIES WITH 
-# REGARD TO THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF 
-# MERCHANTABILITY AND FITNESS, IN NO EVENT SHALL DFKI GMBH NOR THE 
-# CONTRIBUTORS BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL 
-# DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR 
-# PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS 
-# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF 
+#
+# DFKI GMBH AND THE CONTRIBUTORS TO THIS WORK DISCLAIM ALL WARRANTIES WITH
+# REGARD TO THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS, IN NO EVENT SHALL DFKI GMBH NOR THE
+# CONTRIBUTORS BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL
+# DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+# PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 # THIS SOFTWARE.
 ##########################################################################
 
@@ -35,11 +35,10 @@ ICULIBS=-Wl,-R,$(ICUDIR)/lib -L$(ICUDIR)/lib -licuuc -licui18n -ldl
 all: MaryDemo
 
 MaryDemo: MaryClient.o MaryDemo.o
-	$(CC) $(CFLAGS) *.o -o MaryDemo $(LIBS)
+	$(CC) $(CFLAGS) $^ -o MaryDemo $(LIBS)
 
 %.o: %.cc
 	$(CC) $(CFLAGS) $(RFLAGS) -o $@ -c $<
 
 clean:
 	rm -rf *.o ./MaryDemo
-

--- a/doc/examples/client/c++/MaryClient.cc
+++ b/doc/examples/client/c++/MaryClient.cc
@@ -1,14 +1,14 @@
 /**
  * Copyright 2000-2006 DFKI GmbH.
  * All Rights Reserved.  Use is subject to license terms.
- * 
+ *
  * Permission is hereby granted, free of charge, to use and distribute
  * this software and its documentation without restriction, including
  * without limitation the rights to use, copy, modify, merge, publish,
  * distribute, sublicense, and/or sell copies of this work, and to
  * permit persons to whom this work is furnished to do so, subject to
  * the following conditions:
- * 
+ *
  * 1. The code must retain the above copyright notice, this list of
  *    conditions and the following disclaimer.
  * 2. Any modifications must be clearly marked as such.
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <iostream>
 #include <string.h>
+#include <unistd.h>
 
 #include "MaryClient.h"
 
@@ -52,7 +53,7 @@ using namespace std;
 int
 MaryClient::maryQuery( int server_port,
                        string server_host,
-                       string& result, 
+                       string& result,
                        string inputText,
                        string maryInFormat,
                        string maryOutFormat,
@@ -138,7 +139,6 @@ MaryClient::maryQuery( int server_port,
 
   // receive the request id
   char id [32] = "";
-
   if (recv (maryInfoSocket, id, 32, 0) == -1)
   {
     return -2;
@@ -207,18 +207,15 @@ MaryClient::maryQuery( int server_port,
 
   //cout << "Reading result" << endl;
 
-  unsigned int total_bytes = 0;
   int recv_bytes = 0;
-  char data [1024] = "";
+  char data [1024];
 
-  result [0] = '\0';
+  result.clear();
 
   // receive the request result
   do
   {
-    data [0] = '\0';
-
-    recv_bytes = recv (maryDataSocket, data, 1024, 0);
+    recv_bytes = recv (maryDataSocket, data, sizeof(data), 0);
 
     if (recv_bytes == -1)
     {
@@ -226,30 +223,9 @@ MaryClient::maryQuery( int server_port,
     }
     else if (recv_bytes > 0)
     {
-      //cout << "("<<recv_bytes<<")" << endl;
-      total_bytes += recv_bytes;
-      data [recv_bytes] = '\0';
-
-      if (maryOutFormat == "AUDIO")
-      {
-        for (unsigned int i=0; i<recv_bytes; i++)
-        {
-          result += data [i];
-        }
-      }
-      else
-      {
-        result += data;
-      }
+      result.append(data, recv_bytes);
     }
   } while (recv_bytes != 0);
-
-  if (result.size () != total_bytes)
-  {
-    cerr << "error: total bytes received != result bytes!" << endl;
-    cerr << "       total bytes received = " << total_bytes << endl;
-    cerr << "       result bytes = " << result.size () << endl;
-  }
 
   // receive the request error
   do


### PR DESCRIPTION
o Fix verbose and slow way to append to a std::string by using the
  method that is meant for that. Looks like someone in the past
  was confused with c++ strings that can hold binary data vs.
  c strings that are NUL terminated and did some laborious
  workaround.
o Remove leftover debugging code of the c++/c confusion.
o While at it: fix a couple of trailing spaces.
o Makefile fixes.