### PR TITLE
commit fixing #428 (the error when inputting Greek words in German)

### DIFF
--- a/marytts-runtime/src/main/java/marytts/cart/CART.java
+++ b/marytts-runtime/src/main/java/marytts/cart/CART.java
@@ -133,10 +133,7 @@ public class CART extends DirectedGraph {
 		}
 
 		assert currentNode.getNumberOfData() >= minNumberOfData || currentNode == rootNode;
-
-		assert minNumberOfData > 0 || (currentNode instanceof LeafNode);
 		return currentNode;
-
 	}
 
 	/**


### PR DESCRIPTION
the assertion was always false, because currentNode was instantiated as Node, which will never be an instance of LeafNode, and ```minNumberOfData``` was always passed as 0 [```tree.interpretToNode(fv, 0)```]