### PR TITLE
Issue 503: remove the dependency on com.google.common.collect.ImmutableMap

### DIFF
--- a/marytts-runtime/src/main/java/marytts/features/FeatureDefinition.java
+++ b/marytts-runtime/src/main/java/marytts/features/FeatureDefinition.java
@@ -34,8 +34,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
-import com.google.common.collect.ImmutableMap;
-
 import marytts.util.io.StreamUtils;
 import marytts.util.string.ByteStringTranslator;
 import marytts.util.string.IntStringTranslator;
@@ -1697,20 +1695,31 @@ public class FeatureDefinition {
 			out.print("\n");
 		}
 		out.println("ShortValuedFeatureProcessors");
-		for (int i = numByteFeatures; i < numShortFeatures; i++) {
-			String featureName = getFeatureName(i);
+		for (int i = 0; i < numShortFeatures; i++) {
+			int n = i + numByteFeatures;
+			String featureName = getFeatureName(n);
 			out.print("0 | " + featureName);
-			for (int v = 0, vmax = getNumberOfValues(i); v < vmax; v++) {
-				String val = getFeatureValueAsString(i, v);
+			for (int v = 0, vmax = getNumberOfValues(n); v < vmax; v++) {
+				String val = getFeatureValueAsString(n, v);
 				out.print(" " + val);
 			}
 			out.print("\n");
 		}
 		out.println("ContinuousFeatureProcessors");
-		ImmutableMap<String, Integer> map = ImmutableMap.of("unit_duration", 1000, "unit_logf0", 100);
-		for (int i = numByteFeatures; i < numByteFeatures + numContinuousFeatures; i++) {
-			String featureName = getFeatureName(i);
-			int featureValue = map.containsKey(featureName) ? map.get(featureName) : 0;
+		for (int i = 0; i < numContinuousFeatures; i++) {
+			String featureName = getFeatureName(i + numByteFeatures + numShortFeatures);
+			int featureValue;
+			switch(featureName) {
+			case "unit_duration":
+				featureValue = 1000;
+				break;
+			case "unit_logf0":
+				featureValue = 100;
+				break;
+			default:
+				featureValue = 0;
+				break;
+			}
 			out.printf("%d linear | %s\n", featureValue, featureName);
 		}
 		out.flush();


### PR DESCRIPTION
This patch is the fix I'm using for issue #503.  The voice building code depends on ImmutableMap, but it appears that the `mvn install` process does not install that dependency, so trying to build a voice was failing for me.

It looks like other parts of the codebase also have dependencies on com.google.common.collect, and I suppose those would be broken for me as well. But I don't know maven, so I'm not going to try to correct that.

This patch makes the code a little simpler, and corrects an unrelated bug that would appear if numShortFeatures was ever > 0.