### PR TITLE
avoid spawning vocoding threads for REALISED_ACOUSTPARAMS

### DIFF
--- a/marytts-runtime/src/main/java/marytts/modules/HTSEngine.java
+++ b/marytts-runtime/src/main/java/marytts/modules/HTSEngine.java
@@ -198,7 +198,7 @@ public class HTSEngine extends InternalModule {
 	 * @return output
 	 */
 	public MaryData process(MaryData d, List<Target> targetFeaturesList, List<Element> segmentsAndBoundaries,
-			List<Element> tokensAndBoundaries) throws Exception {
+			List<Element> tokensAndBoundaries, String outputParams) throws Exception {
 
 		Voice v = d.getDefaultVoice(); /* This is the way of getting a Voice through a MaryData type */
 		assert v instanceof HMMVoice;
@@ -224,9 +224,11 @@ public class HTSEngine extends InternalModule {
 		HTSVocoder par2speech = new HTSVocoder();
 
 		/* Synthesize speech waveform, generate speech out of sequence of parameters */
-		AudioInputStream ais = par2speech.htsMLSAVocoder(pdf2par, hmmv.getHMMData());
+		AudioInputStream ais = null;
+		if (!"noAudio".equals(outputParams))
+			ais = par2speech.htsMLSAVocoder(pdf2par, hmmv.getHMMData());
 
-		MaryData output = new MaryData(outputType(), d.getLocale());
+		MaryData output = new MaryData(getOutputType(), d.getLocale());
 		if (d.getAudioFileFormat() != null) {
 			output.setAudioFileFormat(d.getAudioFileFormat());
 			if (d.getAudio() != null) {

--- a/marytts-runtime/src/main/java/marytts/modules/synthesis/HMMSynthesizer.java
+++ b/marytts-runtime/src/main/java/marytts/modules/synthesis/HMMSynthesizer.java
@@ -67,10 +67,6 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
-import java.util.StringTokenizer;
-
-import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioInputStream;
 
 import marytts.datatypes.MaryData;
@@ -84,7 +80,6 @@ import marytts.modules.HTSEngine;
 import marytts.modules.MaryModule;
 import marytts.modules.ModuleRegistry;
 import marytts.modules.TargetFeatureLister;
-import marytts.modules.synthesis.Voice.Gender;
 import marytts.server.MaryProperties;
 import marytts.unitselection.select.Target;
 import marytts.util.MaryUtils;
@@ -203,7 +198,7 @@ public class HMMSynthesizer implements WaveformSynthesizer {
 
 				// The actual durations are already fixed in the htsEngine.process()
 				// here i pass segements and boundaries to update the realised acoustparams, dur and f0
-				MaryData audio = htsEngine.process(in, targetFeaturesList, segmentsAndBoundaries, null);
+				MaryData audio = htsEngine.process(in, targetFeaturesList, segmentsAndBoundaries, null, null);
 
 				assert audio.getAudio() != null;
 
@@ -261,7 +256,7 @@ public class HMMSynthesizer implements WaveformSynthesizer {
 			// it is not faster to pass directly a list of targets?
 			// --String targetFeatureString = targetFeatureLister.listTargetFeatures(comp, segmentsAndBoundaries);
 
-			MaryData d = new MaryData(targetFeatureLister.outputType(), voice.getLocale());
+			MaryData d = new MaryData(targetFeatureLister.getOutputType(), voice.getLocale());
 			// --d.setPlainText(targetFeatureString);
 			d.setDefaultVoice(voice);
 
@@ -269,7 +264,7 @@ public class HMMSynthesizer implements WaveformSynthesizer {
 
 			// the actual durations are already fixed in the htsEngine.process()
 			// here i pass segements and boundaries to update the realised acoustparams, dur and f0
-			MaryData audio = htsEngine.process(d, targetFeaturesList, segmentsAndBoundaries, tokensAndBoundaries);
+			MaryData audio = htsEngine.process(d, targetFeaturesList, segmentsAndBoundaries, tokensAndBoundaries, outputParams);
 
 			return audio.getAudio();
 

--- a/marytts-runtime/src/main/java/marytts/server/Request.java
+++ b/marytts-runtime/src/main/java/marytts/server/Request.java
@@ -92,7 +92,7 @@ public class Request {
 	protected Logger logger;
 	protected MaryData inputData;
 	protected MaryData outputData;
-	protected boolean streamAudio = false;;
+	protected boolean streamAudio = false;
 	protected boolean abortRequested = false;
 
 	// Keep track of timing info for each module
@@ -545,14 +545,16 @@ public class Request {
 			// to the Request to each MaryData, and look up request-specific
 			// settings such as default voice and audio file format type
 			// from where it is required.)
-			if (m.outputType() == MaryDataType.get("AUDIO")) {
+			if (m.getOutputType() == MaryDataType.get("AUDIO")) {
 				currentData.setAudioFileFormat(audioFileFormat);
 				currentData.setAudio(new AppendableSequenceAudioInputStream(audioFileFormat.getFormat(), null));
 			}
 			// TODO: The following hack makes sure that the Synthesis module gets outputParams. Make this more general and robust.
-			if (m.outputType() == oneOutputType || m.outputType() == MaryDataType.AUDIO) {
+			if (m.getOutputType() == oneOutputType || m.getOutputType() == MaryDataType.AUDIO) {
 				currentData.setOutputParams(outputParams);
-			}
+				if (m.getOutputType() == MaryDataType.AUDIO && oneOutputType == MaryDataType.REALISED_ACOUSTPARAMS)
+					currentData.setOutputParams("noAudio");
+			} 
 			if (logger.getEffectiveLevel().equals(Level.DEBUG)
 					&& (currentData.getType().isTextType() || currentData.getType().isXMLType())) {
 				logger.debug("Handing the following data to the next module:");


### PR DESCRIPTION
ugly but effective fix for bug #567: (ab)use the outputParams that were previously not interpreted at all by HMM voices to pass a "noAudio" option to not synthesize for REALISED_ACOUSTPARAMS. It might make sense to extend this (e.g. to always pass on this option unless AUDIO is requested), and/or to limit application of this workaround only if (m instanceof HMMSynthesizer).

Let me know what you think.