### PR TITLE
Bugfix german AbbrevEP

### DIFF
--- a/marytts-languages/marytts-lang-de/src/integrationTest/java/marytts/language/de/PreprocessorIT.java
+++ b/marytts-languages/marytts-lang-de/src/integrationTest/java/marytts/language/de/PreprocessorIT.java
@@ -86,4 +86,9 @@ public class PreprocessorIT extends MaryModuleTestCase {
 		processAndCompare("iban3", Locale.GERMAN);
 	}
 
+	@Test
+	public void testvChr() throws Exception {
+		processAndCompare("vChr", Locale.GERMAN);
+	}
+
 }

--- a/marytts-languages/marytts-lang-de/src/integrationTest/resources/marytts/language/de/iban1.preprocessed
+++ b/marytts-languages/marytts-lang-de/src/integrationTest/resources/marytts/language/de/iban1.preprocessed
@@ -16,9 +16,11 @@ R
 </mtu>
 </phonology>
 </prosody>
+<mtu accent="last" orig="16">
 <t>
 sechzehn
 </t>
+</mtu>
 </mtu>
 <mtu accent="last" orig="01">
 <t>

--- a/marytts-languages/marytts-lang-de/src/integrationTest/resources/marytts/language/de/iban2.preprocessed
+++ b/marytts-languages/marytts-lang-de/src/integrationTest/resources/marytts/language/de/iban2.preprocessed
@@ -16,9 +16,11 @@ B
 </mtu>
 </phonology>
 </prosody>
+<mtu accent="last" orig="29">
 <t>
 neunundzwanzig
 </t>
+</mtu>
 </mtu>
 <prosody rate="-20%">
 <phonology precision="precise">
@@ -38,6 +40,7 @@ K
 </mtu>
 </phonology>
 </prosody>
+<mtu accent="last" orig="6016">
 <t>
 sechs
 </t>
@@ -47,6 +50,8 @@ Tausend
 <t>
 sechzehn
 </t>
+</mtu>
+<mtu accent="last" orig="1331">
 <t>
 ein
 </t>
@@ -62,6 +67,8 @@ Hundert
 <t>
 einunddreißig
 </t>
+</mtu>
+<mtu accent="last" orig="9268">
 <t>
 neun
 </t>
@@ -77,9 +84,12 @@ Hundert
 <t>
 achtundsechzig
 </t>
+</mtu>
+<mtu accent="last" orig="19">
 <t>
 neunzehn
 </t>
+</mtu>
 </mtu>
 </s>
 </p>

--- a/marytts-languages/marytts-lang-de/src/integrationTest/resources/marytts/language/de/iban3.preprocessed
+++ b/marytts-languages/marytts-lang-de/src/integrationTest/resources/marytts/language/de/iban3.preprocessed
@@ -15,6 +15,7 @@ E
 </mtu>
 </phonology>
 </prosody>
+<mtu accent="last" orig="12345678901234567890">
 <t>
 eins
 </t>
@@ -75,6 +76,7 @@ neun
 <t>
 null
 </t>
+</mtu>
 </mtu>
 </s>
 </p>

--- a/marytts-languages/marytts-lang-de/src/integrationTest/resources/marytts/language/de/vChr.preprocessed
+++ b/marytts-languages/marytts-lang-de/src/integrationTest/resources/marytts/language/de/vChr.preprocessed
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<maryxml xmlns="http://mary.dfki.de/2002/MaryXML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="0.5" xml:lang="de">
+<p>
+<s>
+<mtu accent="last" orig="2000">
+<t>
+zwei
+</t>
+<t>
+Tausend
+</t>
+</mtu>
+<mtu accent="last" orig="v.Chr.">
+<t>
+vor
+</t>
+<t>
+Christus
+</t>
+</mtu>
+</s>
+</p>
+</maryxml>

--- a/marytts-languages/marytts-lang-de/src/integrationTest/resources/marytts/language/de/vChr.tokenised
+++ b/marytts-languages/marytts-lang-de/src/integrationTest/resources/marytts/language/de/vChr.tokenised
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<maryxml xmlns="http://mary.dfki.de/2002/MaryXML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="0.5" xml:lang="de">
+<p>
+<s>
+<t>
+2000
+</t>
+<t>
+v.
+</t>
+<t>
+Chr.
+</t>
+</s>
+</p>
+</maryxml>

--- a/marytts-languages/marytts-lang-de/src/main/java/marytts/language/de/preprocess/AbbrevEP.java
+++ b/marytts-languages/marytts-lang-de/src/main/java/marytts/language/de/preprocess/AbbrevEP.java
@@ -186,10 +186,10 @@ public class AbbrevEP extends ExpansionPattern {
 			if (REPattern.onlyDigits.matcher(text).find()) {
 				if (Pattern.matches(NumberEP.sInteger, text)) {
 					logger.debug("Expanding as integer: `" + text + "'");
-					exp.addAll(makeNewTokens(token.getOwnerDocument(), number.expandInteger(text)));
+					exp.addAll(makeNewTokens(token.getOwnerDocument(), number.expandInteger(text), true, text));
 				} else {
 					logger.debug("Expanding as digits: `" + text + "'");
-					exp.addAll(makeNewTokens(token.getOwnerDocument(), number.expandDigits(text)));
+					exp.addAll(makeNewTokens(token.getOwnerDocument(), number.expandDigits(text), true, text));
 				}
 
 			} else if (text.length() > 1) {


### PR DESCRIPTION
Integers were expanded without an MTU around them, making it
impossible to reconstruct the original text.

The expanded integer is now wrapped in an MTU.  This also applies to
decimal numbers.

Testcases were updated to reflect the change in the *.preprocessed
files.  A new testcase for the described problem was added.

Fixes #676 