### PR TITLE
ability to exclude expansion patterns from automatic application

### DIFF
--- a/marytts-languages/marytts-lang-de/src/main/java/marytts/language/de/preprocess/ExpansionPattern.java
+++ b/marytts-languages/marytts-lang-de/src/main/java/marytts/language/de/preprocess/ExpansionPattern.java
@@ -21,6 +21,7 @@
 package marytts.language.de.preprocess;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -28,8 +29,10 @@ import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import marytts.datatypes.MaryXML;
+import marytts.server.MaryProperties;
 import marytts.util.MaryUtils;
 import marytts.util.dom.MaryDomUtils;
 
@@ -129,7 +132,14 @@ public abstract class ExpansionPattern {
 	}
 
 	public static List<ExpansionPattern> allPatterns() {
-		return expansionPatterns;
+		List<ExpansionPattern> limitedPatterns = new ArrayList<>(expansionPatterns);
+		List<String> exclusions = MaryProperties.getList("de.preprocess.automatic.expansionpatterns.exclusion.list");
+		// only keep EPs whose classname is not part of the exlusions list
+		limitedPatterns = limitedPatterns.stream().filter(ep -> {
+			return !exclusions.contains(ep.getClass().getName());
+		}).collect(Collectors.toList());
+		System.err.println("TIMOS wilde Liste: " + limitedPatterns.toString());
+		return limitedPatterns;
 	}
 
 	public static ExpansionPattern getPattern(String typeString) {

--- a/marytts-languages/marytts-lang-de/src/main/resources/marytts/language/de/de.config
+++ b/marytts-languages/marytts-lang-de/src/main/resources/marytts/language/de/de.config
@@ -67,6 +67,12 @@ featuremanager.classes.list = \
 ####################### Module settings  ###########################
 ####################################################################
 
+#de.preprocess.automatic.expansionpatterns.exclusion.list = \
+#    marytts.language.de.preprocess.TelephoneEP \
+#    marytts.language.de.preprocess.MultiWordEP \
+#    marytts.language.de.preprocess.TimeEP \
+#    marytts.language.de.preprocess.DurationEP
+
 
 de.allophoneset = jar:/marytts/language/de/lexicon/allophones.de.xml
 


### PR DESCRIPTION
As we're seeing problems with some expansion patterns for German, we implemented a way of configuring the application of expansion patterns: the property de.preprocess.automatic.expansionpatterns.exclusion.list will be read from de.config and considered when returning ExpansionPattern#allPatterns(). 

We appreciate you taking this small extension as it helps us work around buggy and/or over-ambitious EPs.