### PR TITLE
fix env check fail for Java 9-Ubuntu

### DIFF
--- a/marytts-runtime/src/main/java/marytts/server/EnvironmentChecks.java
+++ b/marytts-runtime/src/main/java/marytts/server/EnvironmentChecks.java
@@ -42,8 +42,9 @@ public class EnvironmentChecks {
 	 */
 	public static void check() {
 		// Java version
-		String javaVersion = System.getProperty("java.version");
-		if (Float.parseFloat(javaVersion.substring(0, 3)) < 1.499) {
+		String javaVersion = System.getProperty("java.specification.version");
+
+		if (Float.parseFloat(javaVersion) < 1.499) {
 			// 1.499 instead of 1.5 because of rounding error
 			throw new Error("Wrong java version: Required 1.5, found " + javaVersion);
 		}


### PR DESCRIPTION
I am in Ubuntu 17.10 (a developer version). It installs OpenJDK 9.

The problem is that the Java version is '9-Ubuntu'. So picking the first three digits now become '9-U'. It causes the Float.parseFloat() to fail.

I find that the new version naming is quite strange -- but it causes compatibility problem.

This script reads from `java.specification.version` instead of `java.version`