### PR TITLE
updating marytts to use opennlp 1.9.0

### DIFF
--- a/marytts-runtime/pom.xml
+++ b/marytts-runtime/pom.xml
@@ -70,16 +70,10 @@
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpcore-nio</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.apache.opennlp</groupId>
-			<artifactId>opennlp-maxent</artifactId>
-		</dependency>
 		<dependency>
 			<groupId>org.apache.opennlp</groupId>
 			<artifactId>opennlp-tools</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.easytesting</groupId>
 			<artifactId>fest-assert</artifactId>

--- a/marytts-runtime/src/main/java/marytts/modules/OpenNLPPosTagger.java
+++ b/marytts-runtime/src/main/java/marytts/modules/OpenNLPPosTagger.java
@@ -23,6 +23,7 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -116,7 +117,9 @@ public class OpenNLPPosTagger extends InternalModule {
 			}
 			List<String> partsOfSpeech = null;
 			synchronized (this) {
-				partsOfSpeech = tagger.tag(tokens);
+				// Tagger expects an array, not a list!  TODO: consider
+				String[] res = tagger.tag(tokens.toArray(new String[tokens.size()]));
+				partsOfSpeech = Arrays.asList(res);
 			}
 			tokenIt.setCurrentNode(sentence); // reset treewalker so we can walk through once again
 			Iterator<String> posIt = partsOfSpeech.iterator();

--- a/pom.xml
+++ b/pom.xml
@@ -316,16 +316,10 @@
 				<artifactId>httpcore-nio</artifactId>
 				<version>4.1</version>
 			</dependency>
-
-			<dependency>
-				<groupId>org.apache.opennlp</groupId>
-				<artifactId>opennlp-maxent</artifactId>
-				<version>3.0.3</version>
-			</dependency>
 			<dependency>
 				<groupId>org.apache.opennlp</groupId>
 				<artifactId>opennlp-tools</artifactId>
-				<version>1.5.3</version>
+				<version>1.9.0</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
Hi, Thanks for a great project!  We use MaryTTS in MyRobotLab and recently, we were working on some new features that include the use of OpenNLP version 1.9.0.    Unfortunately, that breaks MaryTTS.  I was hoping I could submit this pull request to update the 5.x branch of Mary to use the latest OpenNLP.
