### PR TITLE
Make IP address binding configurable

### DIFF
--- a/marytts-runtime/conf/marybase.config
+++ b/marytts-runtime/conf/marybase.config
@@ -142,6 +142,9 @@ featuremanager.classes.list =
 server = http
 server.http.parallelthreads = 6
 
+# server socket address:
+socket.addr = 127.0.0.1
+
 # server socket port:
 socket.port = 59125
 

--- a/marytts-runtime/src/main/java/marytts/server/Mary.java
+++ b/marytts-runtime/src/main/java/marytts/server/Mary.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Method;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -496,10 +497,11 @@ public class Mary {
 			System.err.print("a command-line application...");
 
 		// first thing we do, let's test if the port is available:
+		InetAddress localAddr = MaryProperties.needInetAddress("socket.addr");
 		int localPort = MaryProperties.needInteger("socket.port");
 		if (!server.equals("commandline")) {
 			try {
-				ServerSocket serverSocket = new ServerSocket(localPort);
+				ServerSocket serverSocket = new ServerSocket(localPort, 0, localAddr);
 				serverSocket.close();
 			} catch (IOException e) {
 				System.err.println("\nPort " + localPort + " already in use!");
@@ -508,7 +510,7 @@ public class Mary {
 		}
 
 		startup();
-		System.err.println(" started in " + (System.currentTimeMillis() - startTime) / 1000. + " s on port " + localPort);
+		System.err.println(" started in " + (System.currentTimeMillis() - startTime) / 1000. + " s on " + localAddr.getHostAddress() + ":" + localPort);
 
 		Runnable main = null;
 

--- a/marytts-runtime/src/main/java/marytts/server/MaryProperties.java
+++ b/marytts-runtime/src/main/java/marytts/server/MaryProperties.java
@@ -23,6 +23,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -369,6 +371,29 @@ public class MaryProperties {
 			return Integer.decode(value).intValue();
 		} catch (NumberFormatException e) {
 			throw new NoSuchPropertyException("Integer property `" + property + "' in configuration files has wrong value `"
+					+ value + "'");
+		}
+	}
+
+	/**
+	 * Get an InetAddress property from the underlying properties, throwing an exception if it is not defined. If the property contains
+	 * a hostname instead of an IP address it will be resolved, throwing an exception on failure.
+	 * 
+	 * @param property
+	 *            the property requested
+	 * @return the InetAddress property value
+	 * @throws NoSuchPropertyException
+	 *             if the property is not defined.
+	 */
+	public static InetAddress needInetAddress(String property) throws NoSuchPropertyException {
+		String value = getProperty(property);
+		if (value == null) {
+			throw new NoSuchPropertyException("Missing property `" + property + "' in configuration files");
+		}
+		try {
+			return InetAddress.getByName(value);
+		} catch (UnknownHostException e) {
+			throw new NoSuchPropertyException("InetAddress property `" + property + "' in configuration files has wrong value `"
 					+ value + "'");
 		}
 	}

--- a/marytts-runtime/src/main/java/marytts/server/MaryServer.java
+++ b/marytts-runtime/src/main/java/marytts/server/MaryServer.java
@@ -157,7 +157,7 @@ public class MaryServer implements Runnable {
 	public void run() {
 		logger.info("Starting server.");
 		try {
-			server = new ServerSocket(MaryProperties.needInteger("socket.port"));
+			server = new ServerSocket(MaryProperties.needInteger("socket.port"), 0, MaryProperties.needInetAddress("socket.addr"));
 
 			while (true) {
 				logger.info("Waiting for client to connect on port " + server.getLocalPort());

--- a/marytts-runtime/src/main/java/marytts/server/http/MaryHttpServer.java
+++ b/marytts-runtime/src/main/java/marytts/server/http/MaryHttpServer.java
@@ -21,6 +21,7 @@ package marytts.server.http;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
 import marytts.server.MaryProperties;
@@ -162,6 +163,7 @@ public class MaryHttpServer extends Thread {
 	public void run() {
 		logger.info("Starting server.");
 
+		InetAddress localAddr = MaryProperties.needInetAddress("socket.addr");
 		int localPort = MaryProperties.needInteger("socket.port");
 
 		HttpParams params = new BasicHttpParams();
@@ -215,7 +217,7 @@ public class MaryHttpServer extends Thread {
 
 		try {
 			ListeningIOReactor ioReactor = new DefaultListeningIOReactor(numParallelThreads, params);
-			ioReactor.listen(new InetSocketAddress(localPort));
+			ioReactor.listen(new InetSocketAddress(localAddr, localPort));
 			isReady = true;
 			ioReactor.execute(ioEventDispatch);
 		} catch (InterruptedIOException ex) {

--- a/marytts-runtime/src/main/resources/marytts/config/marybase.config
+++ b/marytts-runtime/src/main/resources/marytts/config/marybase.config
@@ -141,6 +141,9 @@ featuremanager.classes.list =
 server = http
 server.http.parallelthreads = 6
 
+# server socket address:
+socket.addr = 127.0.0.1
+
 # server socket port:
 socket.port = 59125
 


### PR DESCRIPTION
This allows to bind the MaryTTS server to a specific IP address instead
of binding it to all available interfaces. It allows IPv4 addresses,
IPv6 addresses and hostnames.

See: #954 