### PR TITLE
groovy-all: 2.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
 			<dependency>
 				<groupId>org.codehaus.groovy</groupId>
 				<artifactId>groovy-all</artifactId>
-				<version>2.4.5</version>
+				<version>2.5.4</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
Should fix https://app.snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSGROOVY-31510.