### PR TITLE
'assert' keyword changed to Objects.requireNonNull

### DIFF
--- a/marytts-languages/marytts-lang-de/src/main/java/marytts/language/de/JPhonemiser.java
+++ b/marytts-languages/marytts-lang-de/src/main/java/marytts/language/de/JPhonemiser.java
@@ -26,15 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.StringTokenizer;
-import java.util.TreeMap;
+import java.util.*;
 
 import marytts.datatypes.MaryData;
 import marytts.datatypes.MaryDataType;
@@ -53,6 +45,8 @@ import org.apache.commons.io.FileUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.traversal.NodeIterator;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * The phonemiser module -- java implementation.
@@ -389,12 +383,12 @@ public class JPhonemiser extends marytts.modules.JPhonemiser {
 	 * @return the transcription, or null if none could be determined.
 	 */
 	public String phonemiseEn(String text) {
-		assert usEnglishLexicon != null;
+		requireNonNull(usEnglishLexicon);
 		// We get here only if there is an English lexicon
 		String normalisedEn = MaryUtils.normaliseUnicodeLetters(text, Locale.US);
 		normalisedEn = normalisedEn.toLowerCase();
 		String[] transcriptions = usEnglishLexicon.lookup(normalisedEn);
-		assert transcriptions != null; // if nothing is found, an array of length 0 is returned.
+		Objects.requireNonNull(transcriptions); // if nothing is found, an array of length 0 is returned.
 		if (transcriptions.length == 0) {
 			return null;
 		}

--- a/marytts-languages/marytts-lang-de/src/main/java/marytts/language/de/phonemiser/Inflection.java
+++ b/marytts-languages/marytts-lang-de/src/main/java/marytts/language/de/phonemiser/Inflection.java
@@ -20,13 +20,7 @@
 package marytts.language.de.phonemiser;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import marytts.datatypes.MaryXML;
 import marytts.util.MaryUtils;
@@ -41,6 +35,8 @@ import org.w3c.dom.traversal.DocumentTraversal;
 import org.w3c.dom.traversal.NodeFilter;
 import org.w3c.dom.traversal.NodeIterator;
 import org.w3c.dom.traversal.TreeWalker;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Add inflection endings to expanded abbreviations and ordinals.
@@ -185,7 +181,7 @@ public class Inflection {
 				String endingClass = it.next();
 				String key = (detType == null ? endingClass : endingClass + detType);
 				String ending = (String) endingTable.get(key);
-				assert (ending != null);
+				requireNonNull(ending);
 				endings.add(ending);
 				logger.debug("...ending class " + endingClass + " with "
 						+ (detType == null ? "no" : (detType.equals("d") ? "definite" : "indefinite")) + " determiner: Ending `e"

--- a/marytts-languages/marytts-lang-en/src/main/java/marytts/language/en/Preprocess.java
+++ b/marytts-languages/marytts-lang-en/src/main/java/marytts/language/en/Preprocess.java
@@ -24,6 +24,8 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * @author Tristan Hamilton
  *
@@ -397,7 +399,7 @@ public class Preprocess extends InternalModule {
                 String[] newTokens = MaryDomUtils.tokenText(t).replaceAll("-", " ").split("\\s+");
                 MaryDomUtils.setTokenText(t, newTokens[0]);
                 for (int i = 1; i < newTokens.length; i++) {
-                    assert t != null;
+                    requireNonNull(t);
                     MaryDomUtils.appendToken(t, newTokens[i]);
                     t = MaryDomUtils.getNextSiblingElement(t);
                     // if tokens are an expanded contraction

--- a/marytts-languages/marytts-lang-en/src/main/java/marytts/language/en/PronunciationModel.java
+++ b/marytts-languages/marytts-lang-en/src/main/java/marytts/language/en/PronunciationModel.java
@@ -20,6 +20,7 @@
 package marytts.language.en;
 
 import java.util.Locale;
+import java.util.Objects;
 
 import marytts.datatypes.MaryXML;
 import marytts.modules.phonemiser.Allophone;
@@ -28,6 +29,8 @@ import marytts.util.dom.MaryDomUtils;
 
 import org.w3c.dom.Element;
 import org.w3c.dom.traversal.TreeWalker;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * A pronunciation model that takes into account some English postlexical rules.
@@ -94,7 +97,7 @@ public class PronunciationModel extends marytts.modules.PronunciationModel {
 
 	private void prependSchwa(Element currentSegment) {
 		Element syllable = (Element) currentSegment.getParentNode();
-		assert syllable != null;
+		requireNonNull(syllable);
 		Element schwa = MaryXML.createElement(syllable.getOwnerDocument(), MaryXML.PHONE);
 		schwa.setAttribute("p", "@");
 		syllable.insertBefore(schwa, currentSegment);

--- a/marytts-languages/marytts-lang-it/src/main/java/marytts/language/it/Preprocess.java
+++ b/marytts-languages/marytts-lang-it/src/main/java/marytts/language/it/Preprocess.java
@@ -20,10 +20,7 @@
 
 package marytts.language.it;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 
 import marytts.datatypes.MaryData;
 import marytts.datatypes.MaryDataType;
@@ -40,6 +37,8 @@ import org.w3c.dom.NodeList;
 import org.w3c.dom.traversal.DocumentTraversal;
 import org.w3c.dom.traversal.NodeFilter;
 import org.w3c.dom.traversal.TreeWalker;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * The preprocessing module.
@@ -114,7 +113,7 @@ public class Preprocess extends InternalModule {
 					assert !expanded.isEmpty();
 					// need to correct tw
 					Element lastToken = getLastToken(expanded);
-					assert lastToken != null;
+					requireNonNull(lastToken);
 					tw.setCurrentNode(lastToken);
 					logger.debug("set treewalker position:" + MaryDomUtils.getPlainTextBelow((Element) tw.getCurrentNode()));
 				} else { // not fully expanded

--- a/marytts-runtime/src/main/java/marytts/modules/CARTF0Modeller.java
+++ b/marytts-runtime/src/main/java/marytts/modules/CARTF0Modeller.java
@@ -23,6 +23,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.util.Locale;
+import java.util.Objects;
 
 import marytts.cart.CART;
 import marytts.cart.io.MaryCARTReader;
@@ -48,6 +49,8 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.traversal.NodeIterator;
 import org.w3c.dom.traversal.TreeWalker;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Predict phone durations using a CART.
@@ -224,24 +227,24 @@ public class CARTF0Modeller extends InternalModule {
 				}
 				// only predict F0 values if we have a vowel:
 				if (vowel != null) {
-					assert firstVoiced != null : "First voiced should not be null";
-					assert lastVoiced != null : "Last voiced should not be null";
+					requireNonNull(firstVoiced,"First voiced should not be null");
+					requireNonNull(lastVoiced,"Last voiced should not be null");
 					// Now predict the f0 values using the CARTs:ssh
 					String phone = vowel.getAttribute("p");
 					Target t = new Target(phone, vowel);
 					t.setFeatureVector(currentFeatureComputer.computeFeatureVector(t));
 					float[] left = (float[]) currentLeftCart.interpret(t, 0);
-					assert left != null : "Null frequency";
+					requireNonNull(left,"Null frequency");
 					assert left.length == 2 : "Unexpected frequency length: " + left.length;
 					float leftF0InHz = left[1];
 					float leftStddevInHz = left[0];
 					float[] mid = (float[]) currentMidCart.interpret(t, 0);
-					assert mid != null : "Null frequency";
+					requireNonNull(mid,"Null frequency");
 					assert mid.length == 2 : "Unexpected frequency length: " + mid.length;
 					float midF0InHz = mid[1];
 					float midStddevInHz = mid[0];
 					float[] right = (float[]) currentRightCart.interpret(t, 0);
-					assert right != null : "Null frequency";
+					requireNonNull(right,"Null frequency");
 					assert right.length == 2 : "Unexpected frequency length: " + right.length;
 					float rightF0InHz = right[1];
 					float rightStddevInHz = right[0];

--- a/marytts-runtime/src/main/java/marytts/modules/PolynomialF0Modeller.java
+++ b/marytts-runtime/src/main/java/marytts/modules/PolynomialF0Modeller.java
@@ -20,6 +20,7 @@
 package marytts.modules;
 
 import java.util.Locale;
+import java.util.Objects;
 
 import marytts.cart.DirectedGraph;
 import marytts.cart.io.DirectedGraphReader;
@@ -48,6 +49,8 @@ import org.w3c.dom.traversal.DocumentTraversal;
 import org.w3c.dom.traversal.NodeFilter;
 import org.w3c.dom.traversal.NodeIterator;
 import org.w3c.dom.traversal.TreeWalker;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Predict f0 contours using polynomial curves predicted from a directed graph per syllable.
@@ -158,7 +161,7 @@ public class PolynomialF0Modeller extends InternalModule {
 					if (allophoneSet == null) {
 						allophoneSet = MaryRuntimeUtils.determineAllophoneSet(s);
 					}
-					assert allophoneSet != null;
+					requireNonNull(allophoneSet);
 					Allophone allophone = allophoneSet.getAllophone(phone);
 					if (allophone.isVowel()) {
 						// found a vowel

--- a/marytts-runtime/src/main/java/marytts/modules/SynthesisCallerBase.java
+++ b/marytts-runtime/src/main/java/marytts/modules/SynthesisCallerBase.java
@@ -22,6 +22,7 @@ package marytts.modules;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Locale;
+import java.util.Objects;
 
 import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioInputStream;
@@ -36,6 +37,8 @@ import marytts.modules.synthesis.Voice;
 import marytts.util.data.audio.AppendableSequenceAudioInputStream;
 
 import org.xml.sax.SAXException;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * A base class for a synthesis caller. This can work as a normal MARY module, converting synthesis markup data into audio, or it
@@ -84,7 +87,7 @@ public abstract class SynthesisCallerBase extends InternalModule {
 	 */
 	public MaryData process(MaryData d) throws TransformerConfigurationException, TransformerException, FileNotFoundException,
 			IOException, ParserConfigurationException, SAXException, Exception {
-		assert d.getAudioFileFormat() != null;
+		requireNonNull(d.getAudioFileFormat());
 		assert getState() == MODULE_RUNNING;
 
 		// As the input may contain multipe voice sections,
@@ -104,7 +107,7 @@ public abstract class SynthesisCallerBase extends InternalModule {
 		Voice defaultVoice = d.getDefaultVoice();
 		if (defaultVoice == null) {
 			defaultVoice = Voice.getDefaultVoice(Locale.GERMAN);
-			assert defaultVoice != null;
+			requireNonNull(defaultVoice);
 			logger.info("No default voice associated with data. Assuming global default " + defaultVoice.getName());
 		}
 

--- a/marytts-runtime/src/main/java/marytts/unitselection/concat/BaseUnitConcatenator.java
+++ b/marytts-runtime/src/main/java/marytts/unitselection/concat/BaseUnitConcatenator.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioInputStream;
@@ -51,6 +52,8 @@ import marytts.util.data.DoubleDataSource;
 import marytts.util.data.audio.DDSAudioInputStream;
 
 import org.apache.logging.log4j.Logger;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Concatenates Units and returns an audio stream
@@ -156,7 +159,7 @@ public class BaseUnitConcatenator implements UnitConcatenator {
 	protected void determineTargetPitchmarks(List<SelectedUnit> units) {
 		for (SelectedUnit unit : units) {
 			UnitData unitData = (UnitData) unit.getConcatenationData();
-			assert unitData != null : "Should not have null unitdata here";
+			requireNonNull(unitData,"Should not have null unitdata here");
 			Datagram[] datagrams = unitData.getFrames();
 			Datagram[] frames = null; // frames to realise
 			// The number and duration of the frames to realise

--- a/marytts-runtime/src/main/java/marytts/unitselection/concat/HnmUnitConcatenator.java
+++ b/marytts-runtime/src/main/java/marytts/unitselection/concat/HnmUnitConcatenator.java
@@ -31,6 +31,7 @@ package marytts.unitselection.concat;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 import javax.sound.sampled.AudioInputStream;
 
@@ -48,6 +49,8 @@ import marytts.util.data.BufferedDoubleDataSource;
 import marytts.util.data.Datagram;
 import marytts.util.data.audio.DDSAudioInputStream;
 import marytts.util.math.MathUtils;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * A unit concatenator for harmonics plus noise based speech synthesis
@@ -121,7 +124,7 @@ public class HnmUnitConcatenator extends OverlapUnitConcatenator {
 		for (int i = 0; i < len; i++) {
 			SelectedUnit unit = units.get(i);
 			HnmUnitData unitData = (HnmUnitData) unit.getConcatenationData();
-			assert unitData != null : "Should not have null unitdata here";
+			requireNonNull(unitData,"Should not have null unitdata here");
 			Datagram[] frames = unitData.getFrames();
 			assert frames != null : "Cannot generate audio from null frames";
 			// Generate audio from frames

--- a/marytts-runtime/src/main/java/marytts/unitselection/data/TimelineReader.java
+++ b/marytts-runtime/src/main/java/marytts/unitselection/data/TimelineReader.java
@@ -42,6 +42,7 @@ import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
+import java.util.Objects;
 import java.util.Vector;
 
 import marytts.exceptions.MaryConfigurationException;
@@ -50,6 +51,8 @@ import marytts.util.Pair;
 import marytts.util.data.Datagram;
 import marytts.util.data.MaryHeader;
 import marytts.util.io.StreamUtils;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * The TimelineReader class provides an interface to read regularly or variably spaced datagrams from a Timeline data file in Mary
@@ -168,7 +171,7 @@ public class TimelineReader {
 	 */
 	protected void load(String fileName, boolean tryMemoryMapping) throws IOException, BufferUnderflowException,
 			MaryConfigurationException, NullPointerException {
-		assert fileName != null : "filename is null";
+		requireNonNull(fileName,"filename is null");
 
 		RandomAccessFile file = new RandomAccessFile(fileName, "r");
 		FileChannel fc = file.getChannel();

--- a/marytts-runtime/src/main/java/marytts/util/dom/MaryDomUtils.java
+++ b/marytts-runtime/src/main/java/marytts/util/dom/MaryDomUtils.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Locale;
+import java.util.Objects;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -41,6 +42,8 @@ import org.w3c.dom.traversal.DocumentTraversal;
 import org.w3c.dom.traversal.NodeFilter;
 import org.w3c.dom.traversal.NodeIterator;
 import org.xml.sax.SAXException;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * A collection of utilities for MaryXML DOM manipulation or analysis. No object of class MaryDomUtils is created, all methods are
@@ -66,7 +69,7 @@ public class MaryDomUtils extends DomUtils {
 		if (!t.getNodeName().equals(MaryXML.TOKEN))
 			throw new DOMException(DOMException.INVALID_ACCESS_ERR, "Only t elements allowed, received " + t.getNodeName() + ".");
 		Element parent = (Element) t.getParentNode();
-		assert parent != null;
+		requireNonNull(parent);
 		Document doc = t.getOwnerDocument();
 		Element mtu = MaryXML.createElement(doc, MaryXML.MTU);
 		mtu.setAttribute("orig", orig);


### PR DESCRIPTION
Actually, there is no guarantee that application will be started with -ea argument.
If this will happen, all 'assert' check will be skipped, so the stability of the application will be dramatically decresead.
I propose to change all 'assert' keywords to actual checks - for example i've changed 'assert != null' check to 'Objects.requireNonNull' to ensure that these checks will be evaluated anyway.

