### PR TITLE
Switch OpenJDK distribution to Zulu for GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java-version: [ 8.0.192, 8, 11.0.3, 11, 12, 17 ]
+        java-version: [ 8.0.192, 8, 11.0.3, 11, 12 ]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java-version: [ 8.0.192, 8, 11.0.3, 11, 12 ]
+        java-version: [ 8, 11, 12 ]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java-version:
-          - 8
-          - 11
-          - 12
+        java-version: [ 8.0.192, 8, 11.0.3, 11, 12, 17 ]
     runs-on: ubuntu-latest
 
     steps:
@@ -24,7 +21,7 @@ jobs:
 
       - uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: zulu
           java-version: ${{ matrix.java-version }}
 
       - name: Cache Gradle packages


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). Switching the distribution to Azul Zulu. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. 

Please see more details at Foojay.io:
https://foojay.io/today/github-actions-with-java-part-2/

You may want to squash the commits. I tried to use fixed versions and Java's latest LTS version JDK 17. I reverted to what it was before JDK 8, 11, and 12.

Hope you like it 👍🏼 
Carl