### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Add to your `pom.xml`:
 ```xml
 <repositories>
   <repository>
-    <url>https://jcenter.bintray.com</url>
+    <url>https://mlt.jfrog.io/artifactory/mlt-mvn-releases-local</url>
   </repository>
 </repositories>
 
@@ -72,7 +72,17 @@ Add to your `pom.xml`:
   <dependency>
     <groupId>de.dfki.mary</groupId>
     <artifactId>voice-cmu-slt-hsmm</artifactId>
-    <version>5.2</version>
+    <version>5.2.1</version>
+    <exclusions>
+      <exclusion>
+        <groupId>com.twmacinta</groupId>
+        <artifactId>fast-md5</artifactId>
+      </exclusion>
+      <exclusion>
+         <groupId>gov.nist.math</groupId>
+         <artifactId>Jampack</artifactId>
+      </exclusion>
+    </exclusions>
   </dependency>
 </dependencies>
 ```
@@ -82,11 +92,25 @@ Add to your `pom.xml`:
 Add to your `build.gradle`:
 ```groovy
 repositories {
-  jcenter()
+   mavenCentral()
+
+   exclusiveContent {
+      forRepository {
+         maven {
+            url 'https://mlt.jfrog.io/artifactory/mlt-mvn-releases-local'
+         }
+      }
+      filter {
+         includeGroup 'de.dfki.lt.jtok'
+      }
+   }
 }
 
 dependencies {
-  compile group: 'de.dfki.mary', name: 'voice-cmu-slt-hsmm', version: '5.2'
+   implementation group: 'de.dfki.mary', name: 'voice-cmu-slt-hsmm', version: '5.2.1', {
+      exclude group: 'com.twmacinta', module: 'fast-md5'
+      exclude group: 'gov.nist.math', module: 'Jampack'
+   }
 }
 ```
 


### PR DESCRIPTION
We finally have MaryTTS artifacts on Maven Central for the new [v5.2.1 maintenance release](https://github.com/marytts/marytts/releases/tag/v5.2.1). This was necessary to mitigate dependency resolution errors from downstream consumers who at this point get errors trying to pull files from Bintray/JCenter.

Note that three transitive dependencies are *not* available in Maven Central:
- JTok is hosted on DFKI MLT's Artifactory SaaS instance at https://mlt.jfrog.io/
- Fast-MD5 is obsolete, required only for the legacy component installer, and can be excluded
- Jampack is obsolete, required only for legacy HTNM analysis, and can be safely excluded
